### PR TITLE
Ignore dist removal errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "parcel src/index.html --open",
     "test": "jest",
-    "build": "rm -r dist && parcel build src/index.html"
+    "build": "rm -r dist || parcel build src/index.html"
   },
   "keywords": [],
   "author": "Armando Cordova",


### PR DESCRIPTION
We don't want to stop the ci when dist doesn't exist.